### PR TITLE
Refactor presence tester into modular components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,62 +1,23 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Badge } from "@/components/ui/badge"
+import { useCallback, useEffect, useState } from "react"
+
+import { ApiLogsCard } from "@/components/graph-presence/api-logs-card"
+import { AuthenticationCard } from "@/components/graph-presence/authentication-card"
+import { PreferredPresenceCard } from "@/components/graph-presence/preferred-presence-card"
+import { PresenceCard } from "@/components/graph-presence/presence-card"
+import { SessionPresenceCard } from "@/components/graph-presence/session-presence-card"
+import { UserInfoCard } from "@/components/graph-presence/user-info-card"
+import { Card, CardContent } from "@/components/ui/card"
+import { useApiLogs } from "@/hooks/use-api-logs"
 import { useToast } from "@/hooks/use-toast"
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
-import { ChevronDown, ChevronRight } from "lucide-react"
-
-interface PresenceData {
-  id?: string
-  availability?: string
-  activity?: string
-  statusMessage?: {
-    message?: {
-      content?: string
-      contentType?: string
-    }
-    publishedDateTime?: string
-  }
-}
-
-interface UserData {
-  displayName?: string
-  userPrincipalName?: string
-  id?: string
-}
-
-interface ApiLog {
-  id: string
-  timestamp: string
-  method: string
-  endpoint: string
-  request: any
-  response: any
-  status: "success" | "error"
-  duration: number
-}
-
-const userPresenceOptions = [
-  { availability: "Available", activity: "Available", label: "Available / Available" },
-  { availability: "Busy", activity: "InACall", label: "Busy / In a Call" },
-  { availability: "Busy", activity: "InAConferenceCall", label: "Busy / In a Conference Call" },
-  { availability: "Away", activity: "Away", label: "Away / Away" },
-  { availability: "DoNotDisturb", activity: "Presenting", label: "Do Not Disturb / Presenting" },
-]
-
-const appPresenceOptions = [
-  { availability: "Available", activity: "Available", label: "Available / Available" },
-  { availability: "Busy", activity: "Busy", label: "Busy / Busy" },
-  { availability: "DoNotDisturb", activity: "DoNotDisturb", label: "Do Not Disturb / Do Not Disturb" },
-  { availability: "BeRightBack", activity: "BeRightBack", label: "Be Right Back / Be Right Back" },
-  { availability: "Away", activity: "Away", label: "Away / Away" },
-  { availability: "Offline", activity: "OffWork", label: "Offline / Off Work" },
-]
+import {
+  appPresenceOptions,
+  type PresenceData,
+  type UserData,
+  userPresenceOptions,
+  type ApiLogStatus,
+} from "@/lib/presence"
 
 export default function GraphPresenceTester() {
   const [tenantId, setTenantId] = useState("")
@@ -75,68 +36,24 @@ export default function GraphPresenceTester() {
 
   const [appPresenceSelection, setAppPresenceSelection] = useState(0)
 
-  const [apiLogs, setApiLogs] = useState<ApiLog[]>([])
+  const { toast } = useToast()
+  const { apiLogs, addLog, clearLogs } = useApiLogs()
   const [isLogsOpen, setIsLogsOpen] = useState(false)
 
-  const { toast } = useToast()
+  const addApiLog = useCallback(
+    (method: string, endpoint: string, request: unknown, response: unknown, status: ApiLogStatus, duration: number) => {
+      addLog({ method, endpoint, request, response, status, duration })
+    },
+    [addLog],
+  )
 
-  const stripTokens = (obj: any): any => {
-    if (obj === null || obj === undefined) return obj
-    if (typeof obj === "string") {
-      if (obj.length > 50 && (obj.includes(".") || obj.match(/^[A-Za-z0-9_-]+$/))) {
-        return "[TOKEN_REDACTED]"
-      }
-      return obj
-    }
-    if (Array.isArray(obj)) {
-      return obj.map(stripTokens)
-    }
-    if (typeof obj === "object") {
-      const stripped: any = {}
-      for (const [key, value] of Object.entries(obj)) {
-        if (
-          ["token", "access_token", "authorization", "bearer", "secret", "password"].some((tokenField) =>
-            key.toLowerCase().includes(tokenField),
-          )
-        ) {
-          stripped[key] = "[TOKEN_REDACTED]"
-        } else {
-          stripped[key] = stripTokens(value)
-        }
-      }
-      return stripped
-    }
-    return obj
-  }
-
-  const addApiLog = (
-    method: string,
-    endpoint: string,
-    request: any,
-    response: any,
-    status: "success" | "error",
-    duration: number,
-  ) => {
-    const log: ApiLog = {
-      id: Date.now().toString(),
-      timestamp: new Date().toISOString(),
-      method,
-      endpoint,
-      request: stripTokens(request),
-      response: stripTokens(response),
-      status,
-      duration,
-    }
-    setApiLogs((prev) => [log, ...prev].slice(0, 50))
-  }
-
-  const clearLogs = () => {
-    setApiLogs([])
+  const handleClearLogs = useCallback(() => {
+    clearLogs()
     toast({
       title: "Success",
       description: "API logs cleared",
     })
-  }
+  }, [clearLogs, toast])
 
   useEffect(() => {
     const storedTenantId = localStorage.getItem("graph-tester-tenantId")
@@ -182,7 +99,7 @@ export default function GraphPresenceTester() {
     }
   }, [appSecret])
 
-  const clearStoredData = () => {
+  const clearStoredData = useCallback(() => {
     localStorage.removeItem("graph-tester-tenantId")
     localStorage.removeItem("graph-tester-appId")
     localStorage.removeItem("graph-tester-userObjectId")
@@ -198,73 +115,76 @@ export default function GraphPresenceTester() {
       title: "Success",
       description: "All stored authentication data has been cleared",
     })
-  }
+  }, [toast])
 
-  const makeGraphRequest = async (action: string, body?: any, token?: string) => {
-    const accessToken = token || appToken
-    const startTime = Date.now()
+  const makeGraphRequest = useCallback(
+    async (action: string, body?: unknown, token?: string) => {
+      const accessToken = token || appToken
+      const startTime = Date.now()
 
-    if (!accessToken) {
-      toast({
-        title: "Error",
-        description: "Please acquire an app token first",
-        variant: "destructive",
-      })
-      return null
-    }
-
-    if (!userObjectId) {
-      toast({
-        title: "Error",
-        description: "Please provide a user object ID",
-        variant: "destructive",
-      })
-      return null
-    }
-
-    try {
-      const requestPayload = {
-        token: accessToken,
-        userObjectId,
-        action,
-        body,
+      if (!accessToken) {
+        toast({
+          title: "Error",
+          description: "Please acquire an app token first",
+          variant: "destructive",
+        })
+        return null
       }
 
-      const response = await fetch("/api/presence", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(requestPayload),
-      })
-
-      const duration = Date.now() - startTime
-      const responseData = await response.json()
-
-      if (!response.ok) {
-        addApiLog("POST", `/api/presence (${action})`, requestPayload, responseData, "error", duration)
-        throw new Error(responseData.error || `HTTP ${response.status}`)
+      if (!userObjectId) {
+        toast({
+          title: "Error",
+          description: "Please provide a user object ID",
+          variant: "destructive",
+        })
+        return null
       }
 
-      addApiLog("POST", `/api/presence (${action})`, requestPayload, responseData, "success", duration)
-      return responseData
-    } catch (error) {
-      const duration = Date.now() - startTime
-      const errorResponse = { error: error instanceof Error ? error.message : "Unknown error occurred" }
+      try {
+        const requestPayload = {
+          token: accessToken,
+          userObjectId,
+          action,
+          body,
+        }
 
-      addApiLog("POST", `/api/presence (${action})`, { action, body }, errorResponse, "error", duration)
+        const response = await fetch("/api/presence", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(requestPayload),
+        })
 
-      console.error("Graph API Error:", error)
-      toast({
-        title: "API Error",
-        description: error instanceof Error ? error.message : "Unknown error occurred",
-        variant: "destructive",
-      })
-      return null
-    }
-  }
+        const duration = Date.now() - startTime
+        const responseData = await response.json()
 
-  const getAppToken = async () => {
+        if (!response.ok) {
+          addApiLog("POST", `/api/presence (${action})`, requestPayload, responseData, "error", duration)
+          throw new Error(responseData.error || `HTTP ${response.status}`)
+        }
+
+        addApiLog("POST", `/api/presence (${action})`, requestPayload, responseData, "success", duration)
+        return responseData
+      } catch (error) {
+        const duration = Date.now() - startTime
+        const errorResponse = { error: error instanceof Error ? error.message : "Unknown error occurred" }
+
+        addApiLog("POST", `/api/presence (${action})`, { action, body }, errorResponse, "error", duration)
+
+        console.error("Graph API Error:", error)
+        toast({
+          title: "API Error",
+          description: error instanceof Error ? error.message : "Unknown error occurred",
+          variant: "destructive",
+        })
+        return null
+      }
+    },
+    [addApiLog, appToken, toast, userObjectId],
+  )
+
+  const getAppToken = useCallback(async () => {
     if (!tenantId || !appId || !appSecret) {
       toast({
         title: "Error",
@@ -315,18 +235,13 @@ export default function GraphPresenceTester() {
           setUserData(userData)
         }
 
-        console.log("[v0] Getting presence for user:", userObjectId)
         const body = {
           ids: [userObjectId],
         }
         const presenceData = await makeGraphRequest("getPresence", body, responseData.access_token)
-        console.log("[v0] Presence API response:", presenceData)
 
         if (presenceData && presenceData.value && presenceData.value.length > 0) {
-          console.log("[v0] Setting presence data:", presenceData.value[0])
           setPresenceData(presenceData.value[0])
-        } else {
-          console.log("[v0] No presence data found in response")
         }
 
         toast({
@@ -352,9 +267,9 @@ export default function GraphPresenceTester() {
       setLoading(false)
       return false
     }
-  }
+  }, [addApiLog, appId, appSecret, makeGraphRequest, tenantId, toast, userObjectId])
 
-  const whoAmI = async () => {
+  const whoAmI = useCallback(async () => {
     if (!userObjectId) {
       toast({
         title: "Error",
@@ -374,9 +289,9 @@ export default function GraphPresenceTester() {
       })
     }
     setLoading(false)
-  }
+  }, [makeGraphRequest, toast, userObjectId])
 
-  const getPresence = async () => {
+  const getPresence = useCallback(async () => {
     if (!userObjectId) {
       toast({
         title: "Error",
@@ -387,24 +302,20 @@ export default function GraphPresenceTester() {
     }
 
     setLoading(true)
-    console.log("[v0] Getting presence for user:", userObjectId)
 
     const body = {
       ids: [userObjectId],
     }
 
     const data = await makeGraphRequest("getPresence", body)
-    console.log("[v0] Presence API response:", data)
 
     if (data && data.value && data.value.length > 0) {
-      console.log("[v0] Setting presence data:", data.value[0])
       setPresenceData(data.value[0])
       toast({
         title: "Success",
         description: "Presence data retrieved successfully",
       })
     } else {
-      console.log("[v0] No presence data found in response")
       toast({
         title: "Warning",
         description: "No presence data found for the specified user",
@@ -412,9 +323,9 @@ export default function GraphPresenceTester() {
       })
     }
     setLoading(false)
-  }
+  }, [makeGraphRequest, toast, userObjectId])
 
-  const setUserPresence = async () => {
+  const setUserPresence = useCallback(async () => {
     if (!userObjectId) {
       toast({
         title: "Error",
@@ -442,9 +353,9 @@ export default function GraphPresenceTester() {
       await getPresence()
     }
     setLoading(false)
-  }
+  }, [appId, expirationDuration, getPresence, makeGraphRequest, toast, userObjectId, userPresenceSelection])
 
-  const clearUserPresence = async () => {
+  const clearUserPresence = useCallback(async () => {
     if (!userObjectId) {
       toast({
         title: "Error",
@@ -468,9 +379,9 @@ export default function GraphPresenceTester() {
       await getPresence()
     }
     setLoading(false)
-  }
+  }, [appId, getPresence, makeGraphRequest, toast, userObjectId])
 
-  const setAppPresence = async () => {
+  const setAppPresence = useCallback(async () => {
     if (!userObjectId) {
       toast({
         title: "Error",
@@ -496,9 +407,9 @@ export default function GraphPresenceTester() {
       await getPresence()
     }
     setLoading(false)
-  }
+  }, [appPresenceSelection, getPresence, makeGraphRequest, toast, userObjectId])
 
-  const clearAppPresence = async () => {
+  const clearAppPresence = useCallback(async () => {
     if (!userObjectId) {
       toast({
         title: "Error",
@@ -518,49 +429,7 @@ export default function GraphPresenceTester() {
       await getPresence()
     }
     setLoading(false)
-  }
-
-  const getPresenceColor = (availability?: string, activity?: string) => {
-    if (!availability) return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-
-    switch (availability.toLowerCase()) {
-      case "available":
-        return "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400 border-green-200 dark:border-green-800"
-      case "busy":
-        return "bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400 border-red-200 dark:border-red-800"
-      case "donotdisturb":
-        return "bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400 border-red-200 dark:border-red-800"
-      case "away":
-        return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800"
-      case "berightback":
-        return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800"
-      case "offline":
-        return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200 border-gray-200 dark:border-gray-700"
-      default:
-        return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200 border-gray-200 dark:border-gray-700"
-    }
-  }
-
-  const getPresenceIcon = (availability?: string) => {
-    if (!availability) return "●"
-
-    switch (availability.toLowerCase()) {
-      case "available":
-        return "●"
-      case "busy":
-        return "●"
-      case "donotdisturb":
-        return "⊘"
-      case "away":
-        return "◐"
-      case "berightback":
-        return "◐"
-      case "offline":
-        return "○"
-      default:
-        return "●"
-    }
-  }
+  }, [getPresence, makeGraphRequest, toast, userObjectId])
 
   const isAuthenticated = !!appToken
   const canAuthenticate = tenantId && appId && appSecret
@@ -569,347 +438,71 @@ export default function GraphPresenceTester() {
     <div className="container mx-auto p-6 max-w-4xl">
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-balance">Microsoft Graph Presence API Tester</h1>
-        <p className="text-muted-foreground mt-2">
-          Test Microsoft Graph Presence APIs using client credentials authentication
-        </p>
+        <p className="text-muted-foreground mt-2">Test Microsoft Graph Presence APIs using client credentials authentication</p>
       </div>
 
-      <Card className="mb-6">
-        <CardHeader>
-          <CardTitle>Client Credentials Authentication</CardTitle>
-          <CardDescription>
-            Configure your Azure AD app registration details for client credentials flow
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid md:grid-cols-2 gap-4">
-            <div>
-              <Label htmlFor="tenantId">Tenant ID</Label>
-              <Input
-                id="tenantId"
-                placeholder="Enter your Azure AD tenant ID"
-                value={tenantId}
-                onChange={(e) => setTenantId(e.target.value)}
-              />
-            </div>
-            <div>
-              <Label htmlFor="appId">Application (Client) ID</Label>
-              <Input
-                id="appId"
-                placeholder="Enter your app registration client ID"
-                value={appId}
-                onChange={(e) => setAppId(e.target.value)}
-              />
-            </div>
-          </div>
-          <div>
-            <Label htmlFor="appSecret">Client Secret</Label>
-            <div className="flex gap-2">
-              <Input
-                id="appSecret"
-                type={showSecret ? "text" : "password"}
-                placeholder="Enter your app registration client secret"
-                value={appSecret}
-                onChange={(e) => setAppSecret(e.target.value)}
-                className="flex-1"
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setShowSecret(!showSecret)}
-                className="px-3"
-              >
-                {showSecret ? "Hide" : "Show"}
-              </Button>
-            </div>
-          </div>
-          <div>
-            <Label htmlFor="userObjectId">User Object ID</Label>
-            <Input
-              id="userObjectId"
-              placeholder="Enter the target user's object ID"
-              value={userObjectId}
-              onChange={(e) => setUserObjectId(e.target.value)}
-            />
-          </div>
-
-          <div className="flex gap-2">
-            <Button onClick={getAppToken} disabled={loading || !canAuthenticate}>
-              {loading ? "Acquiring Token..." : "Get App Token"}
-            </Button>
-            <Button variant="outline" onClick={clearStoredData}>
-              Clear Stored Data
-            </Button>
-            {isAuthenticated && (
-              <Badge variant="outline" className="text-green-600">
-                ✓ Authenticated
-              </Badge>
-            )}
-          </div>
-
-          <div className="p-3 bg-blue-50 dark:bg-blue-950/20 rounded-lg border border-blue-200 dark:border-blue-800">
-            <p className="text-sm text-blue-800 dark:text-blue-200">
-              <strong>Required Permissions:</strong> Your app registration needs Presence.ReadWrite.All application
-              permission for client credentials authentication.
-            </p>
-          </div>
-
-          <div className="p-3 bg-amber-50 dark:bg-amber-950/20 rounded-lg border border-amber-200 dark:border-amber-800">
-            <p className="text-sm text-amber-800 dark:text-amber-200">
-              <strong>🔒 Security:</strong> Non-sensitive data (Tenant ID, App ID, User ID) is stored in your browser's
-              localStorage. The client secret is stored in sessionStorage and will be cleared when you close this tab.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+      <AuthenticationCard
+        tenantId={tenantId}
+        appId={appId}
+        appSecret={appSecret}
+        userObjectId={userObjectId}
+        showSecret={showSecret}
+        loading={loading}
+        isAuthenticated={isAuthenticated}
+        canAuthenticate={!!canAuthenticate}
+        onTenantIdChange={setTenantId}
+        onAppIdChange={setAppId}
+        onAppSecretChange={setAppSecret}
+        onUserObjectIdChange={setUserObjectId}
+        onToggleSecret={() => setShowSecret((previous) => !previous)}
+        onGetAppToken={getAppToken}
+        onClearStoredData={clearStoredData}
+      />
 
       <div className="grid md:grid-cols-2 gap-6 mb-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>User Information</CardTitle>
-            <CardDescription>Get information about the target user (Who Am I)</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button onClick={whoAmI} disabled={loading || !isAuthenticated || !userObjectId}>
-              {loading ? "Loading..." : "Who Am I"}
-            </Button>
+        <UserInfoCard
+          userData={userData}
+          loading={loading}
+          isAuthenticated={isAuthenticated}
+          userObjectId={userObjectId}
+          onWhoAmI={whoAmI}
+        />
 
-            {userData && (
-              <div className="mt-4 p-4 bg-muted rounded-lg">
-                <h4 className="font-semibold mb-2">User Information:</h4>
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">Display Name:</span>
-                    <Badge variant="outline">{userData.displayName}</Badge>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">User Principal Name:</span>
-                    <Badge variant="outline">{userData.userPrincipalName}</Badge>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">Object ID:</span>
-                    <Badge variant="outline">{userData.id}</Badge>
-                  </div>
-                </div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Get Presence</CardTitle>
-            <CardDescription>Retrieve current presence information using bulk endpoint</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button onClick={getPresence} disabled={loading || !isAuthenticated || !userObjectId}>
-              {loading ? "Loading..." : "Get Presence"}
-            </Button>
-
-            {presenceData && (
-              <div className="mt-4 p-4 bg-muted rounded-lg">
-                <h4 className="font-semibold mb-2">Current Presence:</h4>
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">Availability:</span>
-                    <Badge className={`${getPresenceColor(presenceData.availability)} font-medium`}>
-                      <span className="mr-1">{getPresenceIcon(presenceData.availability)}</span>
-                      {presenceData.availability}
-                    </Badge>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">Activity:</span>
-                    <Badge className={`${getPresenceColor(presenceData.availability)} font-medium`}>
-                      {presenceData.activity}
-                    </Badge>
-                  </div>
-                  {presenceData.statusMessage?.message?.content && (
-                    <div>
-                      <span className="font-medium">Status Message:</span>
-                      <p className="text-sm text-muted-foreground mt-1">{presenceData.statusMessage.message.content}</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <PresenceCard
+          presenceData={presenceData}
+          loading={loading}
+          isAuthenticated={isAuthenticated}
+          userObjectId={userObjectId}
+          onGetPresence={getPresence}
+        />
       </div>
 
       <div className="grid md:grid-cols-2 gap-6 mb-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Application Session Presence</CardTitle>
-            <CardDescription>Set or clear presence as an application session (uses setPresence API)</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="userPresence">Availability / Activity Combination</Label>
-              <Select
-                value={userPresenceSelection.toString()}
-                onValueChange={(value) => setUserPresenceSelection(Number.parseInt(value))}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {userPresenceOptions.map((option, index) => (
-                    <SelectItem key={index} value={index.toString()}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+        <SessionPresenceCard
+          loading={loading}
+          isAuthenticated={isAuthenticated}
+          userObjectId={userObjectId}
+          userPresenceSelection={userPresenceSelection}
+          expirationDuration={expirationDuration}
+          onSelectPresence={setUserPresenceSelection}
+          onExpirationChange={setExpirationDuration}
+          onSetPresence={setUserPresence}
+          onClearPresence={clearUserPresence}
+        />
 
-            <div className="space-y-2">
-              <Label htmlFor="expirationDuration">Expiration Duration (ISO 8601)</Label>
-              <Input
-                id="expirationDuration"
-                placeholder="PT5M (5 minutes)"
-                value={expirationDuration}
-                onChange={(e) => setExpirationDuration(e.target.value)}
-              />
-            </div>
-
-            <div className="flex gap-2">
-              <Button onClick={setUserPresence} disabled={loading || !isAuthenticated || !userObjectId}>
-                Set Presence
-              </Button>
-              <Button
-                variant="outline"
-                onClick={clearUserPresence}
-                disabled={loading || !isAuthenticated || !userObjectId}
-              >
-                Clear Presence
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>User Preferred Presence</CardTitle>
-            <CardDescription>
-              Set or clear user's preferred presence (uses setUserPreferredPresence API)
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="appPresence">Availability / Activity Combination</Label>
-              <Select
-                value={appPresenceSelection.toString()}
-                onValueChange={(value) => setAppPresenceSelection(Number.parseInt(value))}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {appPresenceOptions.map((option, index) => (
-                    <SelectItem key={index} value={index.toString()}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="flex gap-2 flex-wrap">
-              <Button onClick={setAppPresence} disabled={loading || !isAuthenticated || !userObjectId}>
-                Set User Preferred Presence
-              </Button>
-              <Button
-                variant="outline"
-                onClick={clearAppPresence}
-                disabled={loading || !isAuthenticated || !userObjectId}
-                className="whitespace-nowrap bg-transparent"
-              >
-                Clear Preferred
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+        <PreferredPresenceCard
+          loading={loading}
+          isAuthenticated={isAuthenticated}
+          userObjectId={userObjectId}
+          appPresenceSelection={appPresenceSelection}
+          onSelectPresence={setAppPresenceSelection}
+          onSetPreferredPresence={setAppPresence}
+          onClearPreferredPresence={clearAppPresence}
+        />
       </div>
 
-      <Card className="mb-6">
-        <Collapsible open={isLogsOpen} onOpenChange={setIsLogsOpen}>
-          <CollapsibleTrigger asChild>
-            <CardHeader className="cursor-pointer hover:bg-muted/50 transition-colors">
-              <div className="flex items-center justify-between">
-                <div>
-                  <CardTitle className="flex items-center gap-2">
-                    API Request/Response Logs
-                    <Badge variant="outline" className="text-xs">
-                      {apiLogs.length}
-                    </Badge>
-                  </CardTitle>
-                  <CardDescription>
-                    View detailed logs of all API requests and responses for troubleshooting (tokens are redacted for
-                    security)
-                  </CardDescription>
-                </div>
-                {isLogsOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-              </div>
-            </CardHeader>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <CardContent>
-              <div className="flex justify-between items-center mb-4">
-                <p className="text-sm text-muted-foreground">
-                  Logs are stored in browser memory only and will disappear on page reload.
-                </p>
-                <Button variant="outline" size="sm" onClick={clearLogs} disabled={apiLogs.length === 0}>
-                  Clear Logs
-                </Button>
-              </div>
+      <ApiLogsCard apiLogs={apiLogs} isOpen={isLogsOpen} onToggle={setIsLogsOpen} onClearLogs={handleClearLogs} />
 
-              {apiLogs.length === 0 ? (
-                <div className="text-center py-8 text-muted-foreground">
-                  No API calls logged yet. Make some API requests to see logs here.
-                </div>
-              ) : (
-                <div className="space-y-4">
-                  {apiLogs.map((log) => (
-                    <div key={log.id} className="border rounded-lg p-4 space-y-3">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <Badge variant={log.status === "success" ? "default" : "destructive"}>{log.method}</Badge>
-                          <code className="text-sm bg-muted px-2 py-1 rounded">{log.endpoint}</code>
-                          <Badge
-                            variant="outline"
-                            className={log.status === "success" ? "text-green-600" : "text-red-600"}
-                          >
-                            {log.status}
-                          </Badge>
-                        </div>
-                        <div className="text-xs text-muted-foreground">
-                          {new Date(log.timestamp).toLocaleTimeString()} ({log.duration}ms)
-                        </div>
-                      </div>
-
-                      <div className="grid md:grid-cols-2 gap-4">
-                        <div>
-                          <h5 className="text-sm font-medium mb-2">Request:</h5>
-                          <pre className="text-xs bg-muted p-2 rounded border whitespace-pre-wrap break-words">
-                            {JSON.stringify(log.request, null, 2)}
-                          </pre>
-                        </div>
-                        <div>
-                          <h5 className="text-sm font-medium mb-2">Response:</h5>
-                          <pre className="text-xs bg-muted p-2 rounded border whitespace-pre-wrap break-words">
-                            {JSON.stringify(log.response, null, 2)}
-                          </pre>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </CardContent>
-          </CollapsibleContent>
-        </Collapsible>
-      </Card>
       <Card className="mt-6">
         <CardContent className="pt-6">
           <div className="text-center text-sm text-muted-foreground space-y-3">
@@ -928,9 +521,9 @@ export default function GraphPresenceTester() {
               </a>
             </p>
             <p>
-              Special thanks to <strong>Tom van Leijsen</strong> at <strong>AnywhereNow</strong> for sharing the
-              original script and clarifying the logic on how Microsoft Graph Presence APIs work, which helped create
-              this interactive testing tool.
+              Special thanks to <strong>Tom van Leijsen</strong> at <strong>AnywhereNow</strong> for sharing the original
+              script and clarifying the logic on how Microsoft Graph Presence APIs work, which helped create this
+              interactive testing tool.
             </p>
           </div>
         </CardContent>

--- a/components/graph-presence/api-logs-card.tsx
+++ b/components/graph-presence/api-logs-card.tsx
@@ -1,0 +1,95 @@
+import { ChevronDown, ChevronRight } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
+
+import type { ApiLog } from "@/lib/presence"
+
+interface ApiLogsCardProps {
+  apiLogs: ApiLog[]
+  isOpen: boolean
+  onToggle: (open: boolean) => void
+  onClearLogs: () => void
+}
+
+export const ApiLogsCard = ({ apiLogs, isOpen, onToggle, onClearLogs }: ApiLogsCardProps) => {
+  return (
+    <Card className="mb-6">
+      <Collapsible open={isOpen} onOpenChange={onToggle}>
+        <CollapsibleTrigger asChild>
+          <CardHeader className="cursor-pointer hover:bg-muted/50 transition-colors">
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle className="flex items-center gap-2">
+                  API Request/Response Logs
+                  <Badge variant="outline" className="text-xs">
+                    {apiLogs.length}
+                  </Badge>
+                </CardTitle>
+                <CardDescription>
+                  View detailed logs of all API requests and responses for troubleshooting (tokens are redacted for
+                  security)
+                </CardDescription>
+              </div>
+              {isOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+            </div>
+          </CardHeader>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <CardContent>
+            <div className="flex justify-between items-center mb-4">
+              <p className="text-sm text-muted-foreground">
+                Logs are stored in browser memory only and will disappear on page reload.
+              </p>
+              <Button variant="outline" size="sm" onClick={onClearLogs} disabled={apiLogs.length === 0}>
+                Clear Logs
+              </Button>
+            </div>
+
+            {apiLogs.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground">
+                No API calls logged yet. Make some API requests to see logs here.
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {apiLogs.map((log) => (
+                  <div key={log.id} className="border rounded-lg p-4 space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <Badge variant={log.status === "success" ? "default" : "destructive"}>{log.method}</Badge>
+                        <code className="text-sm bg-muted px-2 py-1 rounded">{log.endpoint}</code>
+                        <Badge variant="outline" className={log.status === "success" ? "text-green-600" : "text-red-600"}>
+                          {log.status}
+                        </Badge>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {new Date(log.timestamp).toLocaleTimeString()} ({log.duration}ms)
+                      </div>
+                    </div>
+
+                    <div className="grid md:grid-cols-2 gap-4">
+                      <div>
+                        <h5 className="text-sm font-medium mb-2">Request:</h5>
+                        <pre className="text-xs bg-muted p-2 rounded border whitespace-pre-wrap break-words">
+                          {JSON.stringify(log.request, null, 2)}
+                        </pre>
+                      </div>
+                      <div>
+                        <h5 className="text-sm font-medium mb-2">Response:</h5>
+                        <pre className="text-xs bg-muted p-2 rounded border whitespace-pre-wrap break-words">
+                          {JSON.stringify(log.response, null, 2)}
+                        </pre>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  )
+}

--- a/components/graph-presence/authentication-card.tsx
+++ b/components/graph-presence/authentication-card.tsx
@@ -1,0 +1,129 @@
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+type OnChange = (value: string) => void
+
+interface AuthenticationCardProps {
+  tenantId: string
+  appId: string
+  appSecret: string
+  userObjectId: string
+  showSecret: boolean
+  loading: boolean
+  isAuthenticated: boolean
+  canAuthenticate: boolean
+  onTenantIdChange: OnChange
+  onAppIdChange: OnChange
+  onAppSecretChange: OnChange
+  onUserObjectIdChange: OnChange
+  onToggleSecret: () => void
+  onGetAppToken: () => void | Promise<unknown>
+  onClearStoredData: () => void
+}
+
+export const AuthenticationCard = ({
+  tenantId,
+  appId,
+  appSecret,
+  userObjectId,
+  showSecret,
+  loading,
+  isAuthenticated,
+  canAuthenticate,
+  onTenantIdChange,
+  onAppIdChange,
+  onAppSecretChange,
+  onUserObjectIdChange,
+  onToggleSecret,
+  onGetAppToken,
+  onClearStoredData,
+}: AuthenticationCardProps) => {
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle>Client Credentials Authentication</CardTitle>
+        <CardDescription>Configure your Azure AD app registration details for client credentials flow</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid md:grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="tenantId">Tenant ID</Label>
+            <Input
+              id="tenantId"
+              placeholder="Enter your Azure AD tenant ID"
+              value={tenantId}
+              onChange={(event) => onTenantIdChange(event.target.value)}
+            />
+          </div>
+          <div>
+            <Label htmlFor="appId">Application (Client) ID</Label>
+            <Input
+              id="appId"
+              placeholder="Enter your app registration client ID"
+              value={appId}
+              onChange={(event) => onAppIdChange(event.target.value)}
+            />
+          </div>
+        </div>
+
+        <div>
+          <Label htmlFor="appSecret">Client Secret</Label>
+          <div className="flex gap-2">
+            <Input
+              id="appSecret"
+              type={showSecret ? "text" : "password"}
+              placeholder="Enter your app registration client secret"
+              value={appSecret}
+              onChange={(event) => onAppSecretChange(event.target.value)}
+              className="flex-1"
+            />
+            <Button type="button" variant="outline" size="sm" onClick={onToggleSecret} className="px-3">
+              {showSecret ? "Hide" : "Show"}
+            </Button>
+          </div>
+        </div>
+
+        <div>
+          <Label htmlFor="userObjectId">User Object ID</Label>
+          <Input
+            id="userObjectId"
+            placeholder="Enter the target user's object ID"
+            value={userObjectId}
+            onChange={(event) => onUserObjectIdChange(event.target.value)}
+          />
+        </div>
+
+        <div className="flex gap-2 items-center flex-wrap">
+          <Button onClick={onGetAppToken} disabled={loading || !canAuthenticate}>
+            {loading ? "Acquiring Token..." : "Get App Token"}
+          </Button>
+          <Button variant="outline" onClick={onClearStoredData}>
+            Clear Stored Data
+          </Button>
+          {isAuthenticated && (
+            <Badge variant="outline" className="text-green-600">
+              ✓ Authenticated
+            </Badge>
+          )}
+        </div>
+
+        <div className="p-3 bg-blue-50 dark:bg-blue-950/20 rounded-lg border border-blue-200 dark:border-blue-800">
+          <p className="text-sm text-blue-800 dark:text-blue-200">
+            <strong>Required Permissions:</strong> Your app registration needs Presence.ReadWrite.All application
+            permission for client credentials authentication.
+          </p>
+        </div>
+
+        <div className="p-3 bg-amber-50 dark:bg-amber-950/20 rounded-lg border border-amber-200 dark:border-amber-800">
+          <p className="text-sm text-amber-800 dark:text-amber-200">
+            <strong>🔒 Security:</strong> Non-sensitive data (Tenant ID, App ID, User ID) is stored in your browser's
+            localStorage. The client secret is stored in sessionStorage and will be cleared when you close this tab.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/graph-presence/preferred-presence-card.tsx
+++ b/components/graph-presence/preferred-presence-card.tsx
@@ -1,0 +1,66 @@
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+import { appPresenceOptions } from "@/lib/presence"
+
+interface PreferredPresenceCardProps {
+  loading: boolean
+  isAuthenticated: boolean
+  userObjectId: string
+  appPresenceSelection: number
+  onSelectPresence: (value: number) => void
+  onSetPreferredPresence: () => void | Promise<unknown>
+  onClearPreferredPresence: () => void | Promise<unknown>
+}
+
+export const PreferredPresenceCard = ({
+  loading,
+  isAuthenticated,
+  userObjectId,
+  appPresenceSelection,
+  onSelectPresence,
+  onSetPreferredPresence,
+  onClearPreferredPresence,
+}: PreferredPresenceCardProps) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>User Preferred Presence</CardTitle>
+        <CardDescription>Set or clear user's preferred presence (uses setUserPreferredPresence API)</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="appPresence">Availability / Activity Combination</Label>
+          <Select value={appPresenceSelection.toString()} onValueChange={(value) => onSelectPresence(Number.parseInt(value))}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {appPresenceOptions.map((option, index) => (
+                <SelectItem key={index} value={index.toString()}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex gap-2 flex-wrap">
+          <Button onClick={onSetPreferredPresence} disabled={loading || !isAuthenticated || !userObjectId}>
+            Set User Preferred Presence
+          </Button>
+          <Button
+            variant="outline"
+            onClick={onClearPreferredPresence}
+            disabled={loading || !isAuthenticated || !userObjectId}
+            className="whitespace-nowrap bg-transparent"
+          >
+            Clear Preferred
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/graph-presence/presence-card.tsx
+++ b/components/graph-presence/presence-card.tsx
@@ -1,0 +1,57 @@
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+import type { PresenceData } from "@/lib/presence"
+import { getPresenceColor, getPresenceIcon } from "@/lib/presence"
+
+interface PresenceCardProps {
+  presenceData: PresenceData | null
+  loading: boolean
+  isAuthenticated: boolean
+  userObjectId: string
+  onGetPresence: () => void | Promise<unknown>
+}
+
+export const PresenceCard = ({ presenceData, loading, isAuthenticated, userObjectId, onGetPresence }: PresenceCardProps) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Get Presence</CardTitle>
+        <CardDescription>Retrieve current presence information using bulk endpoint</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button onClick={onGetPresence} disabled={loading || !isAuthenticated || !userObjectId}>
+          {loading ? "Loading..." : "Get Presence"}
+        </Button>
+
+        {presenceData && (
+          <div className="mt-4 p-4 bg-muted rounded-lg">
+            <h4 className="font-semibold mb-2">Current Presence:</h4>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="font-medium">Availability:</span>
+                <Badge className={`${getPresenceColor(presenceData.availability)} font-medium`}>
+                  <span className="mr-1">{getPresenceIcon(presenceData.availability)}</span>
+                  {presenceData.availability}
+                </Badge>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="font-medium">Activity:</span>
+                <Badge className={`${getPresenceColor(presenceData.availability)} font-medium`}>
+                  {presenceData.activity}
+                </Badge>
+              </div>
+              {presenceData.statusMessage?.message?.content && (
+                <div>
+                  <span className="font-medium">Status Message:</span>
+                  <p className="text-sm text-muted-foreground mt-1">{presenceData.statusMessage.message.content}</p>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/graph-presence/session-presence-card.tsx
+++ b/components/graph-presence/session-presence-card.tsx
@@ -1,0 +1,76 @@
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+import { userPresenceOptions } from "@/lib/presence"
+
+interface SessionPresenceCardProps {
+  loading: boolean
+  isAuthenticated: boolean
+  userObjectId: string
+  userPresenceSelection: number
+  expirationDuration: string
+  onSelectPresence: (value: number) => void
+  onExpirationChange: (value: string) => void
+  onSetPresence: () => void | Promise<unknown>
+  onClearPresence: () => void | Promise<unknown>
+}
+
+export const SessionPresenceCard = ({
+  loading,
+  isAuthenticated,
+  userObjectId,
+  userPresenceSelection,
+  expirationDuration,
+  onSelectPresence,
+  onExpirationChange,
+  onSetPresence,
+  onClearPresence,
+}: SessionPresenceCardProps) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Application Session Presence</CardTitle>
+        <CardDescription>Set or clear presence as an application session (uses setPresence API)</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="userPresence">Availability / Activity Combination</Label>
+          <Select value={userPresenceSelection.toString()} onValueChange={(value) => onSelectPresence(Number.parseInt(value))}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {userPresenceOptions.map((option, index) => (
+                <SelectItem key={index} value={index.toString()}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="expirationDuration">Expiration Duration (ISO 8601)</Label>
+          <Input
+            id="expirationDuration"
+            placeholder="PT5M (5 minutes)"
+            value={expirationDuration}
+            onChange={(event) => onExpirationChange(event.target.value)}
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <Button onClick={onSetPresence} disabled={loading || !isAuthenticated || !userObjectId}>
+            Set Presence
+          </Button>
+          <Button variant="outline" onClick={onClearPresence} disabled={loading || !isAuthenticated || !userObjectId}>
+            Clear Presence
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/graph-presence/user-info-card.tsx
+++ b/components/graph-presence/user-info-card.tsx
@@ -1,0 +1,49 @@
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+import type { UserData } from "@/lib/presence"
+
+interface UserInfoCardProps {
+  userData: UserData | null
+  loading: boolean
+  isAuthenticated: boolean
+  userObjectId: string
+  onWhoAmI: () => void | Promise<unknown>
+}
+
+export const UserInfoCard = ({ userData, loading, isAuthenticated, userObjectId, onWhoAmI }: UserInfoCardProps) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>User Information</CardTitle>
+        <CardDescription>Get information about the target user (Who Am I)</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button onClick={onWhoAmI} disabled={loading || !isAuthenticated || !userObjectId}>
+          {loading ? "Loading..." : "Who Am I"}
+        </Button>
+
+        {userData && (
+          <div className="mt-4 p-4 bg-muted rounded-lg">
+            <h4 className="font-semibold mb-2">User Information:</h4>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="font-medium">Display Name:</span>
+                <Badge variant="outline">{userData.displayName}</Badge>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="font-medium">User Principal Name:</span>
+                <Badge variant="outline">{userData.userPrincipalName}</Badge>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="font-medium">Object ID:</span>
+                <Badge variant="outline">{userData.id}</Badge>
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/hooks/use-api-logs.ts
+++ b/hooks/use-api-logs.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState } from "react"
+
+import type { ApiLog, ApiLogInput } from "@/lib/presence"
+
+const SENSITIVE_KEYS = ["token", "access_token", "authorization", "bearer", "secret", "password"]
+
+const shouldRedactString = (value: string) => {
+  if (value.length <= 50) {
+    return false
+  }
+
+  return value.includes(".") || /^[A-Za-z0-9_-]+$/.test(value)
+}
+
+const stripTokens = (input: unknown): unknown => {
+  if (input === null || input === undefined) {
+    return input
+  }
+
+  if (typeof input === "string") {
+    return shouldRedactString(input) ? "[TOKEN_REDACTED]" : input
+  }
+
+  if (Array.isArray(input)) {
+    return input.map((item) => stripTokens(item))
+  }
+
+  if (typeof input === "object") {
+    return Object.entries(input as Record<string, unknown>).reduce<Record<string, unknown>>((acc, [key, value]) => {
+      if (SENSITIVE_KEYS.some((field) => key.toLowerCase().includes(field))) {
+        acc[key] = "[TOKEN_REDACTED]"
+      } else {
+        acc[key] = stripTokens(value)
+      }
+      return acc
+    }, {})
+  }
+
+  return input
+}
+
+export const useApiLogs = () => {
+  const [apiLogs, setApiLogs] = useState<ApiLog[]>([])
+
+  const addLog = useCallback((log: ApiLogInput) => {
+    const entry: ApiLog = {
+      ...log,
+      id: Date.now().toString(),
+      timestamp: new Date().toISOString(),
+      request: stripTokens(log.request),
+      response: stripTokens(log.response),
+    }
+
+    setApiLogs((previous) => [entry, ...previous].slice(0, 50))
+  }, [])
+
+  const clearLogs = useCallback(() => {
+    setApiLogs([])
+  }, [])
+
+  return { apiLogs, addLog, clearLogs }
+}

--- a/lib/presence.ts
+++ b/lib/presence.ts
@@ -1,0 +1,101 @@
+export interface PresenceData {
+  id?: string
+  availability?: string
+  activity?: string
+  statusMessage?: {
+    message?: {
+      content?: string
+      contentType?: string
+    }
+    publishedDateTime?: string
+  }
+}
+
+export interface UserData {
+  displayName?: string
+  userPrincipalName?: string
+  id?: string
+}
+
+export type ApiLogStatus = "success" | "error"
+
+export interface ApiLog {
+  id: string
+  timestamp: string
+  method: string
+  endpoint: string
+  request: any
+  response: any
+  status: ApiLogStatus
+  duration: number
+}
+
+export interface ApiLogInput {
+  method: string
+  endpoint: string
+  request: any
+  response: any
+  status: ApiLogStatus
+  duration: number
+}
+
+export const userPresenceOptions = [
+  { availability: "Available", activity: "Available", label: "Available / Available" },
+  { availability: "Busy", activity: "InACall", label: "Busy / In a Call" },
+  { availability: "Busy", activity: "InAConferenceCall", label: "Busy / In a Conference Call" },
+  { availability: "Away", activity: "Away", label: "Away / Away" },
+  { availability: "DoNotDisturb", activity: "Presenting", label: "Do Not Disturb / Presenting" },
+]
+
+export const appPresenceOptions = [
+  { availability: "Available", activity: "Available", label: "Available / Available" },
+  { availability: "Busy", activity: "Busy", label: "Busy / Busy" },
+  { availability: "DoNotDisturb", activity: "DoNotDisturb", label: "Do Not Disturb / Do Not Disturb" },
+  { availability: "BeRightBack", activity: "BeRightBack", label: "Be Right Back / Be Right Back" },
+  { availability: "Away", activity: "Away", label: "Away / Away" },
+  { availability: "Offline", activity: "OffWork", label: "Offline / Off Work" },
+]
+
+export const getPresenceColor = (availability?: string) => {
+  if (!availability) {
+    return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+  }
+
+  switch (availability.toLowerCase()) {
+    case "available":
+      return "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400 border-green-200 dark:border-green-800"
+    case "busy":
+      return "bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400 border-red-200 dark:border-red-800"
+    case "donotdisturb":
+      return "bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400 border-red-200 dark:border-red-800"
+    case "away":
+    case "berightback":
+      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800"
+    case "offline":
+      return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200 border-gray-200 dark:border-gray-700"
+    default:
+      return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200 border-gray-200 dark:border-gray-700"
+  }
+}
+
+export const getPresenceIcon = (availability?: string) => {
+  if (!availability) {
+    return "●"
+  }
+
+  switch (availability.toLowerCase()) {
+    case "available":
+      return "●"
+    case "busy":
+      return "●"
+    case "donotdisturb":
+      return "⊘"
+    case "away":
+    case "berightback":
+      return "◐"
+    case "offline":
+      return "○"
+    default:
+      return "●"
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the presence tester page to orchestrate smaller components instead of containing all UI and logic inline
- add dedicated cards for authentication, user info, presence controls, and API log viewing to improve readability
- centralize presence types, options, and API logging utilities for reuse across the new components

## Testing
- pnpm lint *(fails: command prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68d688dfdef48328b23fb1f5d8f29c55